### PR TITLE
Add EKS Security Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ module "security_groups" {
 | Name | Description |
 |------|-------------|
 | efs_security_group_id | EFS Security Group ID |
+| eks_control_plane_security_group_id | EKS Control Plane Security Group ID |
+| eks_worker_security_group_id | EKS Worker Security Group ID |
 | elastic_cache_memcache_security_group_id | ElasticCache Memcache Security Group ID |
 | elastic_cache_redis_security_group_id | ElasticCache Redis Security Group ID |
 | mssql_security_group_id | MS SQL DB Security Group ID |
@@ -43,4 +45,5 @@ module "security_groups" {
 | public_ssh_security_group_id | Public SSH Security Group ID |
 | public_web_security_group_id | Public Web Security Group ID |
 | redshift_security_group_id | Redshift Security Group ID |
+| vpc_endpoint_security_group_id | VPC Endpoint Security Group ID |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,16 @@ output "efs_security_group_id" {
   value       = "${aws_security_group.efs_security_group.id}"
 }
 
+output "eks_control_plane_security_group_id" {
+  description = "EKS Control Plane Security Group ID"
+  value       = "${aws_security_group.eks_control_plane_security_group.id}"
+}
+
+output "eks_worker_security_group_id" {
+  description = "EKS Worker Security Group ID"
+  value       = "${aws_security_group.eks_worker_security_group.id}"
+}
+
 output "mssql_security_group_id" {
   description = "MS SQL DB Security Group ID"
   value       = "${aws_security_group.mssql_security_group.id}"


### PR DESCRIPTION
Adds two security groups for use with EKS.

To avoid cyclic references, the ingress and egress rules for the EKS Control Plane group are added via `aws_security_group_rule` resources.