### PR TITLE
Add control plane ingress to worker nodes for port 443

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -706,6 +706,14 @@ resource "aws_security_group" "eks_worker_security_group" {
   }
 
   ingress {
+    description     = "Allow secure ingress traffic from EKS control plane security group"
+    from_port       = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.eks_control_plane_security_group.id]
+    to_port         = 443
+  }
+
+  ingress {
     description = "Allow all ingress traffic from other members of this security group"
     from_port   = 0
     protocol    = "-1"


### PR DESCRIPTION
* As per AWS requirements, add an ingress rule to the EKS worker for port 443 traffic from the EKS control plane

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
